### PR TITLE
fix: resolve Linux headless compatibility issues

### DIFF
--- a/home/dot_config/git/config.tmpl
+++ b/home/dot_config/git/config.tmpl
@@ -103,12 +103,10 @@
 
 [safe]
   directory = *
-{{- if eq .chezmoi.os "darwin" }}
-
+{{ if eq .chezmoi.os "darwin" }}
 [credential]
   helper = osxkeychain
-{{ end -}}
-
+{{ end }}
 [include]
   # Include aliases.
   path = ~/.config/git/aliases

--- a/home/dot_config/mise/config.toml
+++ b/home/dot_config/mise/config.toml
@@ -9,6 +9,7 @@ ruby = "4.0.1"
 # Util
 bat           = "latest"
 delta         = "latest"
+direnv        = "latest"
 1password-cli = "latest"
 chezmoi       = "latest"
 doggo         = "1.0.5"


### PR DESCRIPTION
## Summary

- **Add direnv to mise config** so it's available cross-platform, not just via Brewfile on macOS
- **Fix git config template whitespace** where aggressive `{{-` trim markers merged `[safe]` and `[include]` sections onto one line, breaking git alias/include loading on Linux
- **Remove deprecated 1Password account arg** from `onepasswordRead` calls that was causing template errors

## Test plan

- [ ] Open a new bash shell on Linux — no `defaults` or `direnv` errors
- [ ] Verify `git config --list` includes aliases from `~/.config/git/aliases`
- [ ] Verify `chezmoi apply` renders `config.tmpl` with proper `[safe]` / `[include]` separation on both macOS and Linux
- [ ] Verify `direnv --version` resolves via mise on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux headless setup by correcting git config template whitespace and making direnv available via mise so shells start clean and git aliases load on Linux.

- **New Features**
  - Add direnv to mise for cross-platform availability (no Homebrew dependency).

- **Bug Fixes**
  - Remove deprecated 1Password account argument from onepasswordRead to prevent template errors on machines without a signed-in account.
  - Adjust git config templating to avoid aggressive whitespace trimming, keeping [safe] and [include] on separate lines.

<sup>Written for commit 86e345cca3f7a58eb55cb8f44eaea53320d82677. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

