### PR TITLE
chore: fix claude default model drift (opusplan)

### DIFF
--- a/home/dot_claude/settings.json
+++ b/home/dot_claude/settings.json
@@ -82,7 +82,7 @@
     ],
     "defaultMode": "plan"
   },
-  "model": "claude-fable-5[1m]",
+  "model": "opusplan",
   "hooks": {
     "PostToolUse": [
       {

--- a/home/dot_config/git/ignore
+++ b/home/dot_config/git/ignore
@@ -107,3 +107,5 @@ CLAUDE.local.md
 **/.claude/settings.local.json
 
 **/.claude/.cc-writes/
+
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Reconciled `home/dot_claude/settings.json`'s `model` field, which had drifted three ways: HEAD carried a stale terminal-escape artifact (`claude-fable-5[1m]`) left over from an earlier capture, an uncommitted staged value was already stale, and the live target had since moved on. Set to `opusplan` per explicit current preference (updated both chezmoi source and the live `~/.claude/settings.json`).
- Confirmed (via per-file `chezmoi diff`) that every other managed dotfile has zero drift from source.
- Left the live-only `aicodemetricsd`/Superset notify hooks present in `~/.claude/settings.json` out of source, per instruction — they stay machine-local.
- Added `**/.claude/worktrees/` to the global gitignore — Claude Code background-job isolation creates git worktrees there inside project repos.

## Follow-up (not in this PR)
- `chezmoi diff`/`apply` can't process `.config/git/config` or `.config/zsh/00-exports.sh` because the 1Password CLI can't reach the 1Password desktop app. Needs `Settings > Developer > Integrate with 1Password CLI` toggled on in the 1Password app.

## Test plan
- [x] `chezmoi diff ~/.claude/settings.json` shows only the expected residual hook/ordering differences, nothing model-related
- [x] `git status` clean after each commit