### PR TITLE
fix: confine work-only tooling to the work profile

### DIFF
--- a/home/.chezmoi.toml.tmpl
+++ b/home/.chezmoi.toml.tmpl
@@ -5,7 +5,7 @@
 
 {{/* boolean feature tags */}}
 {{- $ephemeral := false -}}{{/* true if this machine is ephemeral, e.g. a cloud or VM instance */}}
-{{- $work := false -}}{{/* true if this machine is a work machine */}}
+{{- $work := hasSuffix "@betterment.com" $email -}}
 {{- $headless := false -}}{{/* true if this machine does not have a screen and keyboard */}}
 {{- $personal := false -}}{{/* true if this machine should have personal secrets */}}
 
@@ -29,9 +29,6 @@
 {{- if not $ephemeral -}}
 {{-   if eq $hostname "shadowbox" -}}
 {{-     $personal = true -}}
-{{-   else if eq $hostname "REM-BETTERMENT02134" -}}
-{{-     $work = true -}}
-{{-     $headless = false -}}
 {{-   else if eq $hostname "ubuntu" -}}
 {{-     $headless = true -}}
 {{-     $personal = true -}}

--- a/home/chezmoi-toml.bats
+++ b/home/chezmoi-toml.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+render_init() {
+	printf '[data]\nname = "Test"\nemail = "%s"\ngithubUsername = "test"\n' "$1" \
+		>"$BATS_TEST_TMPDIR/chezmoi.toml"
+	chezmoi -c "$BATS_TEST_TMPDIR/chezmoi.toml" --config-format=toml \
+		execute-template --init <"$BATS_TEST_DIRNAME/.chezmoi.toml.tmpl"
+}
+
+data_flag() {
+	render_init "$2" | sed -n "s/^[[:space:]]*$1 = \(.*\)$/\1/p"
+}
+
+@test "a betterment email marks the machine as work whatever its hostname is" {
+	[ "$(data_flag work robert.white@betterment.com)" = "true" ]
+}
+
+@test "a non betterment email leaves the machine personal" {
+	[ "$(data_flag work rob@personal.example)" = "false" ]
+}
+
+@test "a work machine is never granted personal secrets" {
+	[ "$(data_flag personal robert.white@betterment.com)" = "false" ]
+}
+
+@test "the rendered config is valid toml" {
+	run render_init robert.white@betterment.com
+	[ "$status" -eq 0 ]
+	echo "$output" | python3 -c 'import sys, tomllib; tomllib.loads(sys.stdin.read())'
+}

--- a/home/dot_claude/private_settings.json.tmpl
+++ b/home/dot_claude/private_settings.json.tmpl
@@ -1,16 +1,4 @@
-{{- /*
-  ~/.claude/settings.json — templated for multiple machines.
-
-  Machine selection: $isWork is true on the work machine. It is auto-detected by
-  the work account's username, or you can force it with `work = true` in that
-  machine's ~/.config/chezmoi/chezmoi.toml [data]. Personal machines get the else
-  branch. To onboard another work machine, set work = true in its chezmoi data.
-
-  The config is assembled as a data structure (shared base + per-machine overlays)
-  and emitted with toPrettyJson, so the output is always valid JSON. Claude Code
-  does not care about key order (toPrettyJson serialises keys alphabetically).
-*/ -}}
-{{- $isWork := or .work (eq .chezmoi.username "robblakey") -}}
+{{- $isWork := .work -}}
 
 {{- /* ---------- env (shared: 400k compaction window on both machines) ---------- */ -}}
 {{- $env := dict "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "1" "CLAUDE_CODE_AUTO_COMPACT_WINDOW" "400000" -}}
@@ -61,17 +49,20 @@
 {{- $hooks := dict -}}
 {{- if $isWork -}}
 {{-   $aiwatch := dict "matcher" "" "hooks" (list (dict "type" "command" "command" "/usr/local/lib/runlayer/aiwatch/aiwatch hook --client claude_code")) -}}
+{{-   $dxHook := list (dict "type" "command" "command" "/usr/local/bin/aicodemetricsd hook claude --hook-input stdin" "timeout" 2) -}}
+{{-   $dxOnEdit := dict "matcher" "Write|Edit|MultiEdit" "hooks" $dxHook -}}
+{{-   $dxOnEvent := dict "hooks" $dxHook -}}
 {{-   $hooks = dict
-        "PostToolUse" (list $symlinkHook $aiwatch)
-        "PreToolUse" (list $aiwatch)
+        "PostToolUse" (list $symlinkHook $dxOnEdit $aiwatch)
+        "PreToolUse" (list $dxOnEdit $aiwatch)
         "PostToolUseFailure" (list $aiwatch)
-        "SessionStart" (list $aiwatch)
-        "SessionEnd" (list $aiwatch)
+        "SessionStart" (list $dxOnEvent $aiwatch)
+        "SessionEnd" (list $dxOnEvent $aiwatch)
         "UserPromptSubmit" (list $aiwatch)
         "SubagentStart" (list $aiwatch)
         "SubagentStop" (list $aiwatch)
         "Stop" (list $aiwatch)
-        "PreCompact" (list $aiwatch)
+        "PreCompact" (list $dxOnEvent $aiwatch)
         "PermissionRequest" (list $aiwatch)
         "Notification" (list $aiwatch)
         "TeammateIdle" (list $aiwatch)
@@ -115,15 +106,16 @@
       "worktrunk" (dict "source" (dict "source" "github" "repo" "max-sixty/worktrunk")) -}}
 
 {{- /* ---------- sandbox ---------- */ -}}
-{{- $domains := list "github.com" "*.github.com" "*.npmjs.org" "registry.npmjs.org" "rubygems.org" "*.rubygems.org" "pypi.org" "*.pypi.org" "betterconfluence.atlassian.net" -}}
-{{- $sockets := list "~/.gnupg/S.gpg-agent" -}}
+{{- $domains := list "github.com" "*.github.com" "*.npmjs.org" "registry.npmjs.org" "rubygems.org" "*.rubygems.org" "pypi.org" "*.pypi.org" -}}
+{{- $gnupg := printf "%s/.gnupg" .chezmoi.homeDir -}}
+{{- $sockets := list (printf "%s/S.gpg-agent" $gnupg) -}}
 {{- if $isWork -}}
-{{-   $domains = concat $domains (list "circleci.com" "app.circleci.com") -}}
-{{-   $sockets = list "~/.gnupg/S.gpg-agent" "~/.gnupg/S.gpg-agent.extra" "~/.gnupg/S.gpg-agent.ssh" -}}
+{{-   $domains = concat $domains (list "betterconfluence.atlassian.net" "circleci.com" "app.circleci.com") -}}
+{{-   $sockets = list (printf "%s/S.gpg-agent" $gnupg) (printf "%s/S.gpg-agent.extra" $gnupg) (printf "%s/S.gpg-agent.ssh" $gnupg) -}}
 {{- end -}}
 {{- $network := dict "allowedDomains" $domains "allowUnixSockets" $sockets "allowLocalBinding" true -}}
 {{- $sandbox := dict "enabled" true "autoAllowBashIfSandboxed" true "network" $network -}}
-{{- if $isWork }}{{ $sandbox = merge $sandbox (dict "filesystem" (dict "allowWrite" (list "~/Library/pnpm/store"))) }}{{ end -}}
+{{- if $isWork }}{{ $sandbox = merge $sandbox (dict "filesystem" (dict "allowWrite" (list (printf "%s/Library/pnpm/store" .chezmoi.homeDir)))) }}{{ end -}}
 
 {{- /* ---------- top-level assembly ---------- */ -}}
 {{- $cfg := dict

--- a/home/dot_claude/settings.json.bats
+++ b/home/dot_claude/settings.json.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+WORK_ONLY_PATTERNS="runlayer aiwatch aicodemetricsd betterment-tools circleci atlassian"
+
+render() {
+	printf '[data]\nwork = %s\n' "$1" >"$BATS_TEST_TMPDIR/chezmoi.toml"
+	chezmoi -c "$BATS_TEST_TMPDIR/chezmoi.toml" --config-format=toml \
+		execute-template <"$BATS_TEST_DIRNAME/private_settings.json.tmpl"
+}
+
+count_matches() {
+	grep -ci "$1" <<<"$2" || true
+}
+
+@test "personal profile excludes every work-only tool" {
+	run render false
+	[ "$status" -eq 0 ]
+
+	local leaked=""
+	for pattern in $WORK_ONLY_PATTERNS; do
+		if [ "$(count_matches "$pattern" "$output")" -ne 0 ]; then
+			leaked="$leaked $pattern"
+		fi
+	done
+	[ -z "$leaked" ] || {
+		echo "personal profile leaked:$leaked"
+		false
+	}
+}
+
+@test "personal profile keeps the rtk and symlink hooks" {
+	run render false
+	[ "$status" -eq 0 ]
+	[ "$(count_matches "rtk-rewrite.sh" "$output")" -eq 1 ]
+	[ "$(count_matches "symlink-plan.sh" "$output")" -eq 1 ]
+}
+
+@test "work profile registers aiwatch on every hook event" {
+	run render true
+	[ "$status" -eq 0 ]
+	[ "$(count_matches "runlayer/aiwatch/aiwatch" "$output")" -eq 16 ]
+}
+
+@test "work profile registers the dx code metrics hooks" {
+	run render true
+	[ "$status" -eq 0 ]
+	[ "$(count_matches "aicodemetricsd" "$output")" -eq 5 ]
+
+	local events
+	events=$(python3 -c '
+import json, sys
+cfg = json.load(sys.stdin)
+print(" ".join(sorted(
+    event
+    for event, entries in cfg["hooks"].items()
+    for entry in entries
+    for hook in entry["hooks"]
+    if "aicodemetricsd" in hook["command"]
+)))' <<<"$output")
+	[ "$events" = "PostToolUse PreCompact PreToolUse SessionEnd SessionStart" ]
+}
+
+@test "work profile matches dx edit hooks to write tools only" {
+	run render true
+	[ "$status" -eq 0 ]
+
+	local matchers
+	matchers=$(python3 -c '
+import json, sys
+cfg = json.load(sys.stdin)
+pairs = []
+for event, entries in sorted(cfg["hooks"].items()):
+    for entry in entries:
+        for hook in entry["hooks"]:
+            if "aicodemetricsd" in hook["command"]:
+                pairs.append(event + "=" + entry.get("matcher", "-"))
+print(" ".join(pairs))' <<<"$output")
+	[ "$matchers" = "PostToolUse=Write|Edit|MultiEdit PreCompact=- PreToolUse=Write|Edit|MultiEdit SessionEnd=- SessionStart=-" ]
+}
+
+@test "work profile keeps betterment plugins and circleci access" {
+	run render true
+	[ "$status" -eq 0 ]
+	[ "$(count_matches "betterment-tools" "$output")" -eq 4 ]
+	[ "$(count_matches "circleci" "$output")" -eq 4 ]
+}
+
+@test "sandbox paths are absolute so claude code cannot rewrite them" {
+	run render true
+	[ "$status" -eq 0 ]
+
+	local paths
+	paths=$(python3 -c '
+import json, sys
+cfg = json.load(sys.stdin)
+sandbox = cfg["sandbox"]
+print("\n".join(sandbox["network"]["allowUnixSockets"] + sandbox["filesystem"]["allowWrite"]))' <<<"$output")
+	[ -n "$paths" ]
+	[ "$(grep -c '^/' <<<"$paths")" -eq "$(wc -l <<<"$paths" | tr -d ' ')" ]
+}
+
+@test "both profiles render valid json" {
+	for profile in true false; do
+		run render "$profile"
+		[ "$status" -eq 0 ]
+		echo "$output" | python3 -m json.tool >/dev/null
+	done
+}


### PR DESCRIPTION
## Context

`home/dot_claude/settings.json.tmpl` already had a `$isWork` split, but the gate was broken so the personal branch had **never rendered**:

```go
{{- $isWork := or .work (eq .chezmoi.username "robblakey") -}}
```

`.work` was already correct. ORing it against a hardcoded username meant any machine logged in as `robblakey` got the work branch. Rendering both profiles produced byte-identical output — 16 runlayer hooks, 4 `betterment-tools` plugins, and 4 CircleCI entries in the *personal* config.

## Changes

**`home/dot_claude/private_settings.json.tmpl`** (renamed from `settings.json.tmpl`)

- Gate on `.work` alone.
- Move `betterconfluence.atlassian.net` out of the *shared* sandbox domains into the work branch — found by the new test, not in the original plan.
- Adopt the DX (`aicodemetricsd`) hooks the MDM daemon injects, so `chezmoi apply` stops deleting them.
- Absolute sandbox paths via `.chezmoi.homeDir`, since Claude Code expands `~` there.
- `private_` prefix so the rendered mode (0600) matches what Claude Code writes.

**`home/.chezmoi.toml.tmpl`**

- Derive `work` from the `@betterment.com` email instead of `LocalHostName == "REM-BETTERMENT02134"`. This Mac now reports `MacBook-Pro`, so a fresh `chezmoi init` rendered `work = false` **and** `ephemeral = true` on the work machine itself.
- `personal` stays hostname-based: its failure mode (stop managing `.ssh`) is the safe direction, whereas deriving it as `not work` would push SSH keys onto the work Mac.

**Tests** — `home/dot_claude/settings.json.bats` and `home/chezmoi-toml.bats`, 12 tests total. Both are `.bats`, already excluded by `.chezmoiignore`, so they are never deployed.

## Verification

All 12 pass, and each fixture failed first for the right reason.

```
bats home/chezmoi-toml.bats home/dot_claude/settings.json.bats   # 12/12
shfmt -d && shellcheck                                           # clean
```

Pre-existing `10-functions.bats` failures are a sandbox `mktemp` restriction, unrelated to this change.

## Known limitation

`chezmoi verify` will **not** stay permanently green. The DX and runlayer daemons rewrite `settings.json` with keys in insertion order, while `toPrettyJson` can only emit them alphabetically. Content converges after `chezmoi apply`; ordering re-diverges on the next daemon write. The functional regression — apply deleting the DX hooks — is fixed.

## Out of band

`~/.superset` and `~/.config/amp` were removed from the machine. Neither is tracked here, so there is no diff. Verified inert first: no running process, no LaunchAgent, not on `PATH`, worktrees empty with no git repos.

## Note

Both commits are **unsigned** — the 1Password agent socket is unavailable (`Couldn't get agent socket?`), which is also why `chezmoi diff` currently fails on `.config/git/config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes profile gating so work-only tooling is applied only on work machines, not personal. Work detection now uses the Betterment email domain instead of a hostname.

- **Bug Fixes**
  - Claude settings: gate on `.work` only (remove hardcoded username); ensure `runlayer`/`aiwatch`, `aicodemetricsd`, `betterment-tools`, and CircleCI are work-only.
  - Sandbox: move `betterconfluence.atlassian.net` to the work profile; use absolute GPG socket and pnpm paths; rename to `private_settings.json.tmpl` for correct 0600 mode.
  - Chezmoi config: derive `work` from `@betterment.com` email; keep `personal` hostname-based. Add `.bats` tests to assert flags, block work-only leaks in personal, and validate JSON/TOML.

<sup>Written for commit 080c3917044b5bf96c9e7f598ec38a599a990b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andimrob/dotfiles/pull/11?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

