### PR TITLE
fix: keep the writing-for-audience plugin on the work profile

### DIFF
--- a/home/dot_claude/private_settings.json.tmpl
+++ b/home/dot_claude/private_settings.json.tmpl
@@ -93,6 +93,7 @@
         "managing-on-call@betterment-tools" true
         "figma@claude-plugins-official" true
         "bookworm@betterment-tools" true
+        "writing-for-audience@betterment-tools" true
         "datadog@claude-plugins-official" true) -}}
 {{- else -}}
 {{-   $plugins = merge $plugins (dict

--- a/home/dot_claude/settings.json.bats
+++ b/home/dot_claude/settings.json.bats
@@ -78,11 +78,19 @@ print(" ".join(pairs))' <<<"$output")
 	[ "$matchers" = "PostToolUse=Write|Edit|MultiEdit PreCompact=- PreToolUse=Write|Edit|MultiEdit SessionEnd=- SessionStart=-" ]
 }
 
-@test "work profile keeps betterment plugins and circleci access" {
+@test "work profile keeps every betterment plugin and circleci access" {
 	run render true
 	[ "$status" -eq 0 ]
-	[ "$(count_matches "betterment-tools" "$output")" -eq 4 ]
 	[ "$(count_matches "circleci" "$output")" -eq 4 ]
+
+	local plugins
+	plugins=$(python3 -c '
+import json, sys
+cfg = json.load(sys.stdin)
+print(" ".join(sorted(
+    name for name in cfg["enabledPlugins"] if name.endswith("@betterment-tools")
+)))' <<<"$output")
+	[ "$plugins" = "bookworm@betterment-tools managing-on-call@betterment-tools session-analyzer@betterment-tools triage-sentry@betterment-tools writing-for-audience@betterment-tools" ]
 }
 
 @test "sandbox paths are absolute so claude code cannot rewrite them" {


### PR DESCRIPTION
## Context

Caught while pre-flighting the first `chezmoi apply` after #11 merged. A semantic (parsed-JSON) comparison of the rendered target against the live `~/.claude/settings.json` showed:

```
plugins diff: -['writing-for-audience@betterment-tools'] +[]
```

`writing-for-audience@betterment-tools` is enabled live but was missing from the template, so `chezmoi apply` would have **silently disabled it**. It was installed after #11 was written.

## Changes

- Add `writing-for-audience@betterment-tools` to the work branch of `enabledPlugins`.
- Replace the `betterment-tools` match count with an assertion on the **exact** plugin set. A bare count had already gone stale once and tells you nothing about *which* plugin drifted.

## Verification

```
bats home/chezmoi-toml.bats home/dot_claude/settings.json.bats   # 12/12
shfmt -d && shellcheck                                           # clean
```

Semantic pre-apply check against the live config, after this change: all 22 hooks preserved (16 aiwatch, 5 DX, 1 symlink-plan), plugin sets identical, sandbox domains and sockets identical. Remaining intended deltas are only `model` (`opus[1m]` → `opusplan`) and the `Write(…)` → `Edit(…)` deny-rule upgrade from #11.

## Note

Commit is **unsigned** — the 1Password agent socket is still unavailable (`Couldn't get agent socket?`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the `writing-for-audience@betterment-tools` plugin enabled in the work profile to prevent `chezmoi apply` from silently disabling it. Tightens tests to catch plugin drift.

- **Bug Fixes**
  - Added `writing-for-audience@betterment-tools` to the work branch of `enabledPlugins`.
  - Replaced a count check with an exact set assertion for `@betterment-tools` plugins.

<sup>Written for commit 97dd9dbbf9fcdbbf910ba0c4157b2c430802a56f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andimrob/dotfiles/pull/12?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

