### PR TITLE
fix: track bootstrap-managed mise settings in the chezmoi source

### DIFF
--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -37,16 +37,14 @@ lockfile = true
 pin = true
 experimental = true
 idiomatic_version_file_enable_tools = ["ruby", "java", "node", "python"]
-{{- if .work }}
 minimum_release_age = "7d"
-{{- end }}
 
 [settings.ruby]
 compile = true
-{{- if .work }}
 
 [settings.github]
 credential_command = "gh auth token"
+{{- if .work }}
 
 [hooks]
 postinstall = "{{ .chezmoi.homeDir }}/.bootstrap/resources/mise_hooks/postinstall"

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -44,8 +44,10 @@ compile = true
 
 [settings.github]
 credential_command = "gh auth token"
-{{- if .work }}
 
 [hooks]
+{{- if .work }}
 postinstall = "{{ .chezmoi.homeDir }}/.bootstrap/resources/mise_hooks/postinstall"
+{{- else }}
+postinstall = "{{ .chezmoi.homeDir }}/.config/mise/hooks/postinstall.sh"
 {{- end }}

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -37,6 +37,17 @@ lockfile = true
 pin = true
 experimental = true
 idiomatic_version_file_enable_tools = ["ruby", "java", "node", "python"]
+{{- if .work }}
+minimum_release_age = "7d"
+{{- end }}
 
 [settings.ruby]
 compile = true
+{{- if .work }}
+
+[settings.github]
+credential_command = "gh auth token"
+
+[hooks]
+postinstall = "{{ .chezmoi.homeDir }}/.bootstrap/resources/mise_hooks/postinstall"
+{{- end }}

--- a/home/dot_config/mise/hooks/executable_postinstall.sh
+++ b/home/dot_config/mise/hooks/executable_postinstall.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${MISE_INSTALLED_TOOLS:-}" in
+  *ruby*)
+    gem update --system --no-document
+    gem install bundler --no-document
+    ;;
+esac

--- a/home/dot_config/zsh/00-exports.sh.tmpl
+++ b/home/dot_config/zsh/00-exports.sh.tmpl
@@ -40,6 +40,8 @@ export GPG_TTY=$(tty)
 export DISABLE_SPRING=true
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
 
+export BUNDLE_COOLDOWN=7
+
 {{- if .work }}
 
 export GITHUB_BMT_PAT={{ onepasswordRead "op://Developer/Github PAT - BMT Bootstrap/password" "my.1password.com" | quote }}


### PR DESCRIPTION
## Summary

- Tracks the three mise settings Betterment bootstrap writes — `github.credential_command`, `minimum_release_age`, `hooks.postinstall` — in the chezmoi source, so `chezmoi apply` stops deleting them.
- The first two render on every machine; they describe a threat model any machine has, not a Betterment policy. Only the **hook path** is machine-specific, selected with `if/else`.
- Ports the hook's Ruby maintenance to personal machines via a dotfiles-owned script, and moves the gem cooldown to `BUNDLE_COOLDOWN` in exports where it belongs.
- On a work machine the mise config render is byte-identical to the current target, so nothing about work-machine mise behavior changes. `[tools]` and `min_version` untouched.

Three commits, each reviewable on its own: track the settings → make two of them unconditional → port the hook.

## Why

`_setup.sh` writes those three settings straight into `~/.config/mise/config.toml`, but the chezmoi source knew nothing about them. So `chezmoi apply` deleted all three, the next bootstrap run put them back, and the two overwrote each other indefinitely.

The visible symptom was `the-book` failing with `mise::config::parse_error` — `unknown field credential_command`. Cause: a stale standalone `mise 2026.1.6` in `~/.local/bin` (Jan 2026, predates the setting) that won PATH resolution in non-login shells ahead of homebrew's `2026.7.16`. `~/.bootstrap/resources/bin/the-book` calls bare `mise` under `set -euo pipefail`, so the unknown field was fatal rather than a warning.

`credential_command` had been deleted locally to silence that, trading a loud failure for a silent one: without a token, mise reads `the-book`'s private release list as `404` and stays pinned to a cached build. Confirmed — `404` unauthenticated vs `200` authenticated. The stale binary has since been removed (unowned leftover — no bootstrap step, no chezmoi entry, no Brewfile; homebrew supplies `2026.7.16`), so the setting is safe to track again.

### Why two settings are unconditional

`minimum_release_age = "7d"` delays installing freshly-published releases so a compromised one has time to be caught — identical value on a personal machine pulling the same tools from the same registries.

`credential_command` raises the GitHub API limit from 60 to 5,000 requests/hour, which matters because most `[tools]` entries track `latest` through `github:`/aqua backends that hit the API on every version resolution. `github.gh_cli_tokens` is already `true` by default and did *not* prevent the 404, so this is doing real work rather than duplicating a default.

Safe to render where `gh` may not be logged in, because a failing credential command is non-fatal — verified with `MISE_GITHUB_CREDENTIAL_COMMAND=/usr/bin/false mise ls-remote 'github:junegunn/fzf'`, which still listed versions and fell back to unauthenticated access silently.

### Why the hook needs `if/else` rather than one shared path

`_setup.sh` rewrites `hooks.postinstall` to its own path on **every** bootstrap run. Pointing both machines at a dotfiles script would therefore be reverted on work machines and reintroduce exactly the drift this branch removes. So work keeps bootstrap's path and personal gets `~/.config/mise/hooks/postinstall.sh`.

The hook's contents are generic Ruby maintenance, and `ruby` is declared unconditionally in `[tools]`, so personal machines were installing Ruby and getting none of it. Two deliberate differences from bootstrap's copy:

- **The cooldown moves out of the hook.** It is machine-global, not per-install, so it becomes `export BUNDLE_COOLDOWN=7`. That env var outranks `~/.bundle/config`, which cannot be tracked here — bootstrap stores a GitHub token in that file.
- **The bundler version pin is dropped.** Installing the latest bundler satisfies bootstrap's `>= 4.0.13` floor without this repo having to track that number as it moves.

## How to verify

- [ ] `chezmoi execute-template --config <(printf '[data]\nwork = true\n') < home/dot_config/mise/config.toml.tmpl` — all three settings, hook points into `~/.bootstrap`
- [ ] `chezmoi execute-template --config <(printf '[data]\nwork = false\n') < home/dot_config/mise/config.toml.tmpl` — same two settings, hook points at `~/.config/mise/hooks/postinstall.sh`, no `.bootstrap` path anywhere
- [ ] `chezmoi diff ~/.config/mise/config.toml` — empty on a work machine
- [ ] `zsh -ic 'echo $BUNDLE_COOLDOWN'` → `7`, and `bundle config get cooldown` reports it as the top-priority source
- [ ] `shellcheck home/dot_config/mise/hooks/executable_postinstall.sh`
- [ ] `bash -c 'the-book --version'` — a version, no TOML error and no 404

A fuller assertion script lives at `.scratch/mise_template_test.sh` locally (untracked): it renders both `.work` branches, checks mise `2026.7.16` accepts each render via `MISE_GLOBAL_CONFIG_FILE`, asserts no `.bootstrap` path leaks into the personal render, and asserts this machine's live config renders the work variant. Happy to promote it alongside `home/dot_config/zsh/10-functions.bats`.

## Risk / rollback

Low. The failure mode of a bad render is mise settings silently dropping on the next `chezmoi apply`, which is why both values of `.work` are asserted rather than just this machine's. Rollback is `git revert` plus `chezmoi apply --force ~/.config/mise ~/.config/zsh/00-exports.sh`.

Not covered by rollback: removing `~/.local/bin/mise` was local machine state, not part of this diff.

Worth knowing, though it changes nothing here: bootstrap's hook has never actually fired on this machine. It was added 2026-06-03 (#424) while Ruby 4.0.1 was installed 2026-01-21, and mise only runs `postinstall` on install. That is why bundler sits at 4.0.3 — the version Ruby 4.0.1 shipped with — rather than the `>= 4.0.13` the hook asks for. The hook is correctly registered and `experimental` is on; it has simply had no Ruby install to run against.

## Known gap (not fixed here)

**Nothing here installs mise.** These dotfiles activate it (`eval "$(mise activate zsh)"`) and declare its tools, but the install comes from `~/.bootstrap/Brewfile` (`brew 'mise'`) on work machines and by hand everywhere else — which is how the stale `~/.local/bin/mise` came to exist and drift six months behind. Consolidating on brew for both would close it, and belongs in its own PR.
