### PR TITLE
feat(terminal): enable tmux OSC 8 hyperlinks and align Ghostty behavior

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -3,3 +3,5 @@ font-family = JetBrains Mono
 font-feature = calt
 font-feature = liga
 font-size = 14
+
+mouse-shift-capture = never

--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -4,5 +4,9 @@ font-feature = calt
 font-feature = liga
 font-size = 14
 theme = 0x96f
+background-opacity = 1
 
 mouse-shift-capture = never
+
+fullscreen = non-native-visible-menu
+macos-non-native-fullscreen = visible-menu

--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -3,5 +3,6 @@ font-family = JetBrains Mono
 font-feature = calt
 font-feature = liga
 font-size = 14
+theme = 0x96f
 
 mouse-shift-capture = never

--- a/home/dot_config/tmux/tmux.conf
+++ b/home/dot_config/tmux/tmux.conf
@@ -82,8 +82,8 @@ bind -T copy-mode-vi Enter send -X copy-pipe-and-cancel "pbcopy"
 
 # True color support
 set -g default-terminal "tmux-256color"
-set -ag terminal-overrides ",xterm-256color:RGB"
-set -ag terminal-overrides ",*:Tc"
+set -ga terminal-features "*:RGB"
+set -ga terminal-features "*:hyperlinks"
 
 # Status bar position
 set -g status-position bottom
@@ -182,3 +182,8 @@ bind -n MouseDown1StatusRight display-menu -x R -y S \
     "Reload Config" r "source-file ~/.config/tmux/tmux.conf; display 'Config reloaded'" \
     "Kill Pane" x "kill-pane" \
     "Kill Window" X "kill-window"
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'wfxr/tmux-fzf-url'
+
+run '~/.config/tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## Summary

- tmux now forwards OSC 8 hyperlinks to the outer terminal, and `prefix + u` opens an fzf URL picker (wfxr/tmux-fzf-url via TPM).
- Ghostty: shift is hardened so programs cannot reclaim it, plus the `0x96f` theme and iTerm-style non-native fullscreen with a visible menu bar.
- Deliberate non-changes: `set -g mouse on` is untouched, and Ghostty gets no `command =` / tmux autostart.

## Why

Links rendered inside tmux panes were not clickable. Root cause was that tmux never declared the `hyperlinks` terminal feature, and it cannot auto-detect OSC 8 support the way it detects RGB — so it silently dropped hyperlinks instead of forwarding them. Declaring `*:hyperlinks` fixes the tmux half.

The remaining half is not a tmux problem at all: Ghostty honours an application's request for mouse reporting, so with `mouse on` a plain click goes to tmux and never reaches Ghostty's link handler. iTerm2 differs by claiming Cmd+click for itself. The working gesture in Ghostty is therefore Shift+Cmd+click, and `mouse-shift-capture = never` stops a program inside tmux (an editor, for instance) from reclaiming shift via `XTSHIFTESCAPE` and silently breaking it.

While in the file, the two legacy true-color lines were replaced by `terminal-features "*:RGB"`. One of them, `xterm-256color:RGB`, was dead code — it never matched, because the outer `TERM` is `xterm-ghostty`.

## How to verify

- [ ] `tmux show-options -s terminal-features | grep hyperlinks` → shows a discrete `*:hyperlinks` entry
- [ ] `tmux info | grep Hls` → present, not `[missing]` (requires a client attached after the change)
- [ ] `printf '\033]8;;https://example.com\033\\Click me\033]8;;\033\\\n'` then Shift+Cmd+click it
- [ ] `C-a u` opens the fzf URL picker
- [ ] `printf '\033[38;2;255;100;0mORANGE\033[0m\n'` still renders true color after the override removal
- [ ] `ghostty +validate-config` exits 0
- [ ] Cmd+Shift+, then Cmd+N → new window is non-native fullscreen with the menu bar visible

## Risk / rollback

Low: configuration only, no code. Revert with `git revert`.

Activation caveats worth knowing rather than rediscovering:

- `terminal-features` is applied when a client attaches, so an existing tmux client keeps `Hls: [missing]` until it reattaches or the server is restarted.
- Ghostty config is read at process start; closing all windows on macOS does not quit the app, so a reload (Cmd+Shift+,) or a real Cmd+Q is required.
- macOS native tabs do not work under non-native fullscreen — it removes the titlebar that tabs require. Irrelevant when multiplexing with tmux, but it rules out Cmd+T.

## Follow-up (not in this PR)

TPM installs into `~/.config/tmux/plugins/` rather than `~/.tmux/plugins/` because an XDG config is present. That directory is outside chezmoi, so this setup will not reproduce on a new machine until a `.chezmoiexternal.toml` entry is added for TPM.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward OSC 8 hyperlinks through `tmux` and make links reliably clickable in `Ghostty` (Shift+Cmd+click). Adds a keyboard URL picker on prefix + u, plus theme and fullscreen tweaks.

- New Features
  - `tmux`: declare `terminal-features` `*:hyperlinks` and `*:RGB` to forward OSC 8 links and keep true color.
  - `tmux`: add `tmux-plugins/tpm` and `wfxr/tmux-fzf-url`; prefix + u opens an fzf URL picker.
  - `Ghostty`: set `mouse-shift-capture = never` so apps can’t steal Shift; Shift+Cmd+click opens links in panes.
  - `Ghostty`: apply theme `0x96f`, use non-native fullscreen with a visible menu bar, keep opacity at 1.

- Migration
  - Reattach or restart `tmux` clients to activate `Hls` (hyperlinks).
  - Reload or restart `Ghostty` to apply the new config.

<sup>Written for commit f79281901fcd2aace16219d4dc73c4f486448523. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andimrob/dotfiles/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

