### PR TITLE
feat(ghostty): auto-attach tmux on every window and map cmd+t to a tmux window

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -10,3 +10,16 @@ mouse-shift-capture = never
 
 fullscreen = non-native-visible-menu
 macos-non-native-fullscreen = visible-menu
+
+command = /opt/homebrew/bin/tmux attach || /opt/homebrew/bin/tmux new-session -s main
+
+keybind = super+t=text:\x01c
+keybind = super+1=text:\x011
+keybind = super+2=text:\x012
+keybind = super+3=text:\x013
+keybind = super+4=text:\x014
+keybind = super+5=text:\x015
+keybind = super+6=text:\x016
+keybind = super+7=text:\x017
+keybind = super+8=text:\x018
+keybind = super+9=text:\x019


### PR DESCRIPTION
## What

Ghostty now starts tmux for **every** new window, attaching an existing session when one is alive and creating `main` only if no server is running. `cmd+t` and `cmd+1`–`cmd+9` are rebound to drive tmux windows instead of Ghostty tabs.

```
command = /opt/homebrew/bin/tmux attach || /opt/homebrew/bin/tmux new-session -s main

keybind = super+t=text:\x01c
keybind = super+1=text:\x011
... through super+9
```

## Why these specific choices

| Choice | Reason |
|---|---|
| `command`, not `initial-command` | `initial-command` applies only to the first surface, so window 1 had tmux and windows 2+ did not |
| `attach \|\| new-session -s main` | plain `new-session -A -s main` created a *second* session instead of attaching the one already running |
| absolute `/opt/homebrew/bin/tmux` | macOS GUI apps inherit an empty `launchctl` PATH, so a bare `tmux` would not resolve |
| `text:\x01c` | sends the tmux prefix (`C-a`) plus `c`, reusing the existing `bind c new-window -c "#{pane_current_path}"` |

## Verification

- `ghostty +validate-config` exits 0
- `chezmoi diff ~/.config/ghostty/config` empty; the file no longer appears in `chezmoi status`
- Confirmed by hand: every new window attaches the running session, and `cmd+t` opens a tmux window

## Known consequence

Two windows attaching the same session are **linked** — switching tmux windows in one switches the other. `window-size latest` prevents the smaller client from shrinking the larger. tmux grouped sessions (`new-session -t <existing>`) would give each window an independent current-window over a shared window set, if that linkage becomes annoying.

## Follow-up (not in this PR)

`~/.config/tmux/plugins/` is still outside chezmoi, so TPM will not reproduce on a new machine. A `.chezmoiexternal.toml` entry would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-attaches `tmux` for every new Ghostty window, creating `main` only if no server is running. Cmd+T and Cmd+1–9 now control `tmux` windows instead of Ghostty tabs.

- **New Features**
  - `command = /opt/homebrew/bin/tmux attach || /opt/homebrew/bin/tmux new-session -s main`
  - Keybinds: `super+t` -> `text:\x01c`, `super+1–9` -> `text:\x011–\x019` (maps to `C-a c` and select-window 1–9)
  - Use absolute `tmux` path because macOS GUI apps start with an empty PATH

<sup>Written for commit 1cb3a2223aa5e82442eada53abb3c555a0db025e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andimrob/dotfiles/pull/15?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

