### PR TITLE
fix(ghostty): attach-or-create tmux session on launch

### DIFF
--- a/home/dot_config/ghostty/config
+++ b/home/dot_config/ghostty/config
@@ -11,7 +11,7 @@ mouse-shift-capture = never
 fullscreen = non-native-visible-menu
 macos-non-native-fullscreen = visible-menu
 
-command = /opt/homebrew/bin/tmux attach || /opt/homebrew/bin/tmux new-session -s main
+command = /opt/homebrew/bin/tmux new-session -A -s main
 
 keybind = super+t=text:\x01c
 keybind = super+1=text:\x011


### PR DESCRIPTION
## Summary

- Replaces the Ghostty `command` with `tmux new-session -A -s main`, so launching attaches to an existing tmux session or creates one.
- The previous `tmux attach || tmux new-session` fallback was unreachable dead code — see Why.
- One line in one file; nothing else touched.

## Why

Ghostty failed to launch with *"Ghostty failed to launch the requested command"* after only **212 ms**. Two causes, both verified:

**1. The `||` fallback could never run.** On macOS, Ghostty wraps `command` as:

```
login -q -flp <user> /bin/bash --noprofile --norc -c "exec -l <command>"
```

The `exec` builtin *replaces* the shell's process image instead of forking, so once `tmux attach` starts there is no bash left to evaluate the right side of `||`. Demonstrated:

```console
$ /bin/bash --noprofile --norc -c 'exec -l /bin/ls /definitely-nonexistent-xyz || echo "FALLBACK-RAN"'
ls: /definitely-nonexistent-xyz: No such file or directory
exit=1
```

`FALLBACK-RAN` never prints. This has been dead since the line landed in #15 — the config only ever worked when a tmux server already happened to exist.

**2. No server means an instant non-zero exit.** With no server, `tmux attach` prints `no server running on /private/tmp/tmux-502/default` and exits 1 in ~200 ms, which matches the reported runtime. Ghostty treats a fast non-zero exit as a launch failure.

`new-session -A` collapses attach-or-create into a single invocation, so nothing needs a surviving shell. From `man tmux` (3.7b): *"The -A flag makes new-session behave like attach-session if session-name already exists."*

## How to verify

Already verified locally on this branch:

- [x] `-A` creates the session when absent (`new-session -A -d -s main` → exit 0, session listed).
- [x] `-A` attaches rather than duplicating when the session exists (re-run selects the attach path; still exactly one session).
- [x] Ghostty's exact wrapper works under a real pty — `script -q /dev/null /bin/bash --noprofile --norc -c 'exec -l tmux new-session -A -s ptytest true'` starts tmux, renders, and exits 0.
- [x] `chezmoi apply ~/.config/ghostty/config` produces a target byte-identical to source.

To confirm after merge:

- [ ] `git pull && chezmoi apply ~/.config/ghostty/config`
- [ ] `chezmoi status ~/.config/ghostty/config` → empty (no drift)
- [ ] With no server (`tmux kill-server`), fully quit Ghostty (`cmd+q`) and relaunch → opens into tmux, no error screen
- [ ] With the session alive, `cmd+n` → attaches to `main` instead of erroring
- [ ] `cmd+t` still opens a tmux window (ctrl-a c); `cmd+1`..`cmd+9` still switch windows

## Risk / rollback

Low. One config line, no state migrated, no feature flag. Revert with `git revert` and re-run `chezmoi apply ~/.config/ghostty/config`.

Two behaviors worth noting, both intentional:

- **Mirroring.** `command` (not `initial-command`) applies to every surface, so a second Ghostty window attaches to the same `main` session and mirrors the first. Accepted, since tabs are driven inside tmux via the existing `keybind = super+t=text:\x01c`.
- **Absolute path kept.** `/opt/homebrew/bin/tmux` stays absolute: Ghostty launched from the Dock inherits no shell `PATH`, and a second tmux (`~/.local/share/mise/installs/tmux/latest/tmux`) shadows Homebrew's on the interactive `PATH`. Both are 3.7b today, so there is no protocol mismatch — the absolute path just removes the ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Ghostty launch command to `/opt/homebrew/bin/tmux new-session -A -s main` so it attaches to the `main` session if it exists or creates it. Fixes the fast-fail launch error when no `tmux` server is running.

- **Bug Fixes**
  - The old `tmux attach || tmux new-session` fallback never ran because Ghostty executes the command with `exec -l`, so the shell didn’t evaluate `||`.
  - Using `new-session -A` handles attach-or-create in one call and prevents the quick non-zero exit Ghostty treated as a launch failure.

<sup>Written for commit f3842ba639368d64453070a290b0e79faffdf796. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andimrob/dotfiles/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

